### PR TITLE
Routing specs updated to directory consumer and CMD after file location

### DIFF
--- a/routing/s3goes.xml
+++ b/routing/s3goes.xml
@@ -53,7 +53,7 @@
     False
   </RoutingSpecProperty>
   <RoutingSpecProperty PropertyName="cmdAfterFile">
-    /s3load.sh $FILENAME
+    /app/s3load.sh $FILENAME
   </RoutingSpecProperty>
   <RoutingSpecProperty PropertyName="sc:DAPS_STATUS">
     R

--- a/routing/s3transmon.xml
+++ b/routing/s3transmon.xml
@@ -32,12 +32,27 @@
   <UsePerformanceMeasurements>false</UsePerformanceMeasurements>
   <OutputFormat>transmit-monitor</OutputFormat>
   <OutputTimeZone>UTC</OutputTimeZone>
-  <ConsumerType>file</ConsumerType>
-  <ConsumerArg>/opendcs_output/transmon-$DATE(yyyyMMddHHmmss)</ConsumerArg>
-  <SinceTime>now - 1 hours</SinceTime>
+  <ConsumerType>directory</ConsumerType>
+  <ConsumerArg>/opendcs_output</ConsumerArg>
+  <SinceTime>now - 2 hours</SinceTime>
   <RoutingSpecNetworkList Name="&lt;Production&gt;"/>
+  <RoutingSpecProperty PropertyName="siteNameType">
+    uuid
+  </RoutingSpecProperty>
+  <RoutingSpecProperty PropertyName="delimiter">
+    ,
+  </RoutingSpecProperty>
+  <RoutingSpecProperty PropertyName="dateFormat">
+    yyyy-MM-dd&apos;T&apos;HH:mmZ
+  </RoutingSpecProperty>
   <RoutingSpecProperty PropertyName="sc:SOURCE_0000">
     GOES_SELFTIMED
+  </RoutingSpecProperty>
+  <RoutingSpecProperty PropertyName="justify">
+    False
+  </RoutingSpecProperty>
+  <RoutingSpecProperty PropertyName="cmdAfterFile">
+    /app/s3load.sh $FILENAME
   </RoutingSpecProperty>
   <RoutingSpecProperty PropertyName="sc:DAPS_STATUS">
     R
@@ -45,16 +60,13 @@
   <RoutingSpecProperty PropertyName="rs.timeApplyTo">
     l
   </RoutingSpecProperty>
-  <RoutingSpecProperty PropertyName="cmdAfterFile">
-    /s3load.sh $FILENAME
+  <RoutingSpecProperty PropertyName="dataType">
+    midas
+  </RoutingSpecProperty>
+  <RoutingSpecProperty PropertyName="addMsgDelim">
+    False
   </RoutingSpecProperty>
   <RoutingSpecProperty PropertyName="filename">
-    transmit_$SITENAME-$DATE(yyyyMMddHHmmss)
-  </RoutingSpecProperty>
-  <RoutingSpecProperty PropertyName="delimiter">
-    ,
-  </RoutingSpecProperty>
-  <RoutingSpecProperty PropertyName="justify">
-    False
+    $SITENAME-t$DATE(yyyyMMddHHmmss)
   </RoutingSpecProperty>
 </RoutingSpec>


### PR DESCRIPTION
Closes USACE/instrumentation#49

Each routing spec saves files in the same output location.  Because of this
the `filename` property is used in the transmit-monitor routing to
differentiate data types.